### PR TITLE
186 magnet api filter

### DIFF
--- a/docs/dev-setup.rst
+++ b/docs/dev-setup.rst
@@ -94,7 +94,7 @@ we need to install that globally in our Python2 environment::
 To setup your local environment you should create a virtualenv and install the
 necessary requirements::
 
-    mkvirtualenv school_inspector mkvirtualenv school_inspector -p `which python3.4`
+    mkvirtualenv school_inspector -p `which python3.4`
     $VIRTUAL_ENV/bin/pip install -r $PWD/requirements/dev.txt
 
 Then create a local settings file and set your ``DJANGO_SETTINGS_MODULE`` to use it::

--- a/docs/dev-setup.rst
+++ b/docs/dev-setup.rst
@@ -94,7 +94,7 @@ we need to install that globally in our Python2 environment::
 To setup your local environment you should create a virtualenv and install the
 necessary requirements::
 
-    mkvirtualenv --python=/usr/bin/python3.4 school_inspector
+    mkvirtualenv school_inspector mkvirtualenv school_inspector -p `which python3.4`
     $VIRTUAL_ENV/bin/pip install -r $PWD/requirements/dev.txt
 
 Then create a local settings file and set your ``DJANGO_SETTINGS_MODULE`` to use it::

--- a/schools/serializers.py
+++ b/schools/serializers.py
@@ -34,7 +34,7 @@ class SchoolListSerializer(geo_serializers.GeoModelSerializer):
         if obj.choice_zone is not None and obj.choice_zone.contains(pt):
             return 'assigned'
         if obj.year_round_zone is not None and obj.year_round_zone.contains(pt):
-            return 'assigned'
+            return 'option'
         if obj.traditional_option_zone is not None and obj.traditional_option_zone.contains(pt):
             return 'assigned'
         if obj.type in ('magnet', 'charter', 'speciality'):

--- a/schools/views.py
+++ b/schools/views.py
@@ -41,10 +41,12 @@ class ActiveSchools(SchoolAPIView):
     def get_queryset(self):
         qs = super(ActiveSchools, self).get_queryset()
         point_in_district = ~Q(district=None) & Q(district__contains=self.pt)
-        option_schools = Q(type__in=('magnet', 'speciality', 'charter'))
+        option_schools = Q(type__in=('speciality', 'charter')) | (Q(type='magnet') & Q(year_round=False))
+        # see https://github.com/codefordurham/school-navigator/issues/186
+        option_magnet_year_round = Q(type='magnet') & Q(year_round_zone__contains=self.pt) & Q(year_round=True)
         # see https://github.com/codefordurham/school-navigator/issues/147
         traditional_options = Q(type="neighborhood") & Q(traditional_option_zone__contains=self.pt)
-        q = point_in_district | option_schools | traditional_options
+        q = point_in_district | option_schools | traditional_options | option_magnet_year_round
         qs = qs.filter(q)
         qs = qs.filter(active=True)
         return qs.distance(self.pt)


### PR DESCRIPTION
This should fix https://github.com/codefordurham/school-navigator/issues/186
- Filter magnet schools to only display if the location point is within the magnet school's zone per http://www.dpsnc.net/files/_AaI16_/adf9dc39f01a638f3745a49013852ec4/Calendar_Magnet_Year-Round_School_Lottery_FAQS_English_2015-16_Assignments.pdf
- When outside of district for year-round magnet schools (but inside year-round zone), the school should appear in the "magnet" list

- (unrelated) Also included an update to the dev setup docs so that python location is not required