### PR TITLE
Refactors district highlight as well as district data fetching

### DIFF
--- a/frontend/app/app.js
+++ b/frontend/app/app.js
@@ -156,11 +156,10 @@ angular.module('SchoolsApp.controllers', ["leaflet-directive"])
               $scope.schools.forEach(function(school) {
                 school.hover = (school.id === schoolId);
               });
-              var districts = $scope.districts.filter(function(a) {
-                return a.id === schoolId;
-              });
-              districts.forEach(function(district) {
-                $scope.geojson.data.push(district);
+              $scope.districts.forEach(function(district) {
+                if(district.id === schoolId) {
+                  $scope.geojson.data.push(district);
+                }
               });
             },
             clear_highlight: function() {
@@ -169,6 +168,7 @@ angular.module('SchoolsApp.controllers', ["leaflet-directive"])
               });
               $scope.geojson.data = [];
             },
+            prevDistricts: [],
             districts: [],
             switchTab: function (eligibility) {
               $scope.eligibility = eligibility;
@@ -222,7 +222,6 @@ angular.module('SchoolsApp.controllers', ["leaflet-directive"])
           }
           function loadMarkers(data) {
               $scope.markers = { home: $scope.markers.home };
-              $scope.districts = [];
               $scope.all_schools = data;
               $scope.schools = [];
               data.filter(function(a) {
@@ -246,8 +245,12 @@ angular.module('SchoolsApp.controllers', ["leaflet-directive"])
                 $scope.schools.push(school);
               }, $scope.markers);
               data.filter(function(a) {
-                return a.eligibility === $scope.eligibility || (a.eligibility === "option" && a.type === $scope.eligibility);
+                return $scope.prevDistricts.indexOf(a.id) === -1 && // Have we already fetched district?
+                  a.type !== 'charter' && // Is it a charter? (doesn't have a geographic zone)
+                  (a.eligibility === $scope.eligibility || // Is eligibility 'assigned'?
+                  (a.eligibility === "option" && a.type === $scope.eligibility)); // Is type 'magnet' or 'charter'?
               }).forEach(function(school) {
+                $scope.prevDistricts.push(school.id);
                 var districtArray = this;
                 Schools.get(school.id).success(function(this_school) {
                   Object.keys($scope.zoneTypes).forEach(function(zone) {


### PR DESCRIPTION
I didn't want to just push this directly because I thought it would be good to have someone look over it before merging.

The first change (lines 159-162) is an improvement in the readability of the code for highlighting the district to display on the map during hover events.

The rest of the changes involve storing the district geography for the duration of the browsing session and keeping track of the schools for which we have already fetched district data. This reduces the number of API calls we are making. Previously, we were fetching all of the district data for all of the schools whose eligibility matches the current location and tab each and every time the location or tab changed.