### PR TITLE
return choice before priority refs #173

### DIFF
--- a/schools/serializers.py
+++ b/schools/serializers.py
@@ -47,10 +47,10 @@ class SchoolListSerializer(geo_serializers.GeoModelSerializer):
             return 'neighborhood'
         if obj.walk_zone is not None and obj.walk_zone.contains(pt):
             return 'walk zone'
-        if obj.priority_zone is not None and obj.priority_zone.contains(pt):
-            return 'priority'
         if obj.choice_zone is not None and obj.choice_zone.contains(pt):
             return 'choice'
+        if obj.priority_zone is not None and obj.priority_zone.contains(pt):
+            return 'priority'
         if obj.traditional_option_zone is not None and obj.traditional_option_zone.contains(pt):
             return 'traditional calendar option'
 

--- a/schools/serializers.py
+++ b/schools/serializers.py
@@ -43,6 +43,9 @@ class SchoolListSerializer(geo_serializers.GeoModelSerializer):
 
     def get_preference(self, obj):
         pt = self.context['point']
+        # return auto-assigned (walk/choice) before other zones
+        # see https://github.com/codefordurham/school-navigator/pull/217
+        the order is important - see https://github.com/codefordurham/school-navigator/pull/217
         if obj.district is not None and obj.district.contains(pt):
             return 'neighborhood'
         if obj.walk_zone is not None and obj.walk_zone.contains(pt):

--- a/schools/serializers.py
+++ b/schools/serializers.py
@@ -45,7 +45,6 @@ class SchoolListSerializer(geo_serializers.GeoModelSerializer):
         pt = self.context['point']
         # return auto-assigned (walk/choice) before other zones
         # see https://github.com/codefordurham/school-navigator/pull/217
-        the order is important - see https://github.com/codefordurham/school-navigator/pull/217
         if obj.district is not None and obj.district.contains(pt):
             return 'neighborhood'
         if obj.walk_zone is not None and obj.walk_zone.contains(pt):


### PR DESCRIPTION
Sandy Ridge has both choice and priority zones. The priority zone fully contains the choice zone, so if you're in the choice zone you're geographically in both zones. Technically, however, if you're in the choice zone, you're not in the priority zone and the choice zone trumps the priority zone.

So we just want to make sure we check for the choice zone first before priority in the API.

refs #173 