### PR TITLE
fixes virtual env spelling in docs

### DIFF
--- a/docs/dev-setup.rst
+++ b/docs/dev-setup.rst
@@ -107,7 +107,7 @@ Then create a local settings file and set your ``DJANGO_SETTINGS_MODULE`` to use
 Exit the virtualenv and reactivate it to activate the settings just changed::
 
     deactivate
-    workon school_inspector
+    workon school_navigator
 
 If you're on Ubuntu 12.04, to get get postgis you need to set up a few more
 packages before you can create the db and set up the postgis extension::


### PR DESCRIPTION
fixes the issue where `school_inspector` needs to be `school_navigator`


![screen shot 2016-08-09 at 6 54 07 pm](https://cloud.githubusercontent.com/assets/13974084/17536726/08953270-5e65-11e6-8a75-9df32a929f75.png)
