### PR TITLE
fixes school website url to open page in new tab

### DIFF
--- a/frontend/app/templates/details.html
+++ b/frontend/app/templates/details.html
@@ -48,7 +48,7 @@
         <div class="col-md-6">
             <p><strong>Address: </strong> {{ school.address }}</p>
             <p><strong>Phone Number: </strong> {{ school.profile.phone_number }}</p>
-            <p><strong>Website: </strong> <a href="{{ school.profile.website_url | uri }}">{{ school.profile.website_url | uri }}</a></p>
+            <p><strong>Website: </strong> <a href="{{ school.profile.website_url | uri }}" target="_blank">{{ school.profile.website_url | uri }}</a></p>
             <p><strong>Year Opened: </strong> {{ school.profile.year_opened }}</p>
         </div>
         <div class="col-md-6">


### PR DESCRIPTION
Changes behavior to look like the GIF below, clicking url opens school's website in a new tab in the same browser window.

resolves #354 

![schoolnav-newtab](https://cloud.githubusercontent.com/assets/13974084/17646553/aa01ac26-619c-11e6-87d3-7cbb560d61c6.gif)


