### PR TITLE
Added missing alt-text to cfd logo on About page

### DIFF
--- a/frontend/app/templates/about.html
+++ b/frontend/app/templates/about.html
@@ -38,7 +38,7 @@
         </div>
         -->
         <a href="http://codefordurham.com/">
-        <img src="img/cfd-logo.png" style="height: 100px; margin-left: auto; margin-right: auto; display: block;" />
+        <img src="img/cfd-logo.png" alt="Go to Code for Durham Website"; style="height: 100px; margin-left: auto; margin-right: auto; display: block;" />
         </a>
     </div>
 </div>

--- a/frontend/app/templates/about.html
+++ b/frontend/app/templates/about.html
@@ -38,7 +38,7 @@
         </div>
         -->
         <a href="http://codefordurham.com/">
-        <img src="img/cfd-logo.png" alt="Go to Code for Durham Website"; style="height: 100px; margin-left: auto; margin-right: auto; display: block;" />
+        <img src="img/cfd-logo.png" alt="Go to Code for Durham Website" style="height: 100px; margin-left: auto; margin-right: auto; display: block;" />
         </a>
     </div>
 </div>


### PR DESCRIPTION
Image link, _cfd-logo.png_, was missing alternative text for screen readers.  Added `alt` tag and text.