### PR TITLE
Cleaned up CSS and HTML to remove the “new-prototype” class

### DIFF
--- a/frontend/app/templates/details-new.html
+++ b/frontend/app/templates/details-new.html
@@ -1,5 +1,5 @@
 <simple-nav></simple-nav>
-<main class="school-detail-page new-prototype">
+<main class="school-detail-page">
     <div class="container-fluid ">
         <div class="row hero" style="background-image: url(/media/{{ school.profile.photo }}), url(../img/mural.jpg)"/>
         </div>
@@ -10,9 +10,9 @@
                     <p class="lead">{{ school.school_type }} | {{ school.grades }}</p>
                 </div>
             </div>
-          <div>
-            <a class="btn btn-school-website" href="{{ school.profile.website_url | uri }}">Visit the Official School Website</a>
-          </div>
+            <div>
+                <a class="btn btn-school-website" href="{{ school.profile.website_url | uri }}">Visit the Official School Website</a>
+            </div>
         </div>
 
         <nav class="row school-profile-tabs middle-school-tabs-nav">

--- a/frontend/css/index.css
+++ b/frontend/css/index.css
@@ -429,6 +429,9 @@ div#schools-wrapper ul.nav li.active a, div#schools-wrapper ul.nav li a:hover {
 
  /*SCHOOL DETAIL PAGE*/
 
+.school-detail-page {
+    margin-bottom: 60px;
+}
 .school-detail-page ol {
     padding-left: 20px;
 }
@@ -439,8 +442,19 @@ div#schools-wrapper ul.nav li.active a, div#schools-wrapper ul.nav li a:hover {
 .school-detail-page ul li {
     padding-bottom: 10px;
 }
-.school-detail-page {
-    margin-bottom: 40px;
+.school-detail-page .school-profile-tabs ul li {
+    text-align: center;
+    text-transform: uppercase;
+    width: 20%;
+    padding-bottom: 0;
+}
+.school-detail-page .nav-pills > li+li {
+    margin: 0;
+}
+.school-profile-tabs .nav-pills > li.active > a,
+.school-profile-tabs .nav-pills > li > a:hover {
+    border-radius: 0;
+    cursor: pointer;
 }
 .btn-school-website {
     font-size: 21px;
@@ -504,11 +518,9 @@ div.avgline span.avg {
 .map-row .angular-leaflet-map {
     margin-top: 20px;
 }
-
 .overlay {
     display: none;
 }
-
 .coming-soon .overlay {
     opacity: 1;
     display: block;
@@ -547,71 +559,45 @@ div.avgline span.avg {
 .coming-soon.teacher-survey .overlay .opacity {
     opacity: 0.7;
 }
-
-
-/* NEW PROTOTYPE STYLES */
-/* ========================
-Once the new school profile page is implemented,
-the follwoing styles will have to be refactored to remove .new-prototype class
-and integrated with other styles above
-=========================== */
-
-.new-prototype.school-detail-page {
-    margin-bottom: 60px;
-}
-.new-prototype .container {
+.container {
     margin-top: 0;
 }
-.new-prototype .container,
-.new-prototype .container-fluid {
+.container,
+.container-fluid {
     position: relative;
 }
-.new-prototype .hero {
+.hero {
     height: 350px;
     opacity: 0.25;
 }
-.new-prototype .school-profile-header {
+.school-profile-header {
     margin-top: -250px;
 }
-.new-prototype .school-profile-header.middle-school {
+.school-profile-header.middle-school {
     color: #666;
 }
-.new-prototype nav.school-profile-tabs {
+nav.school-profile-tabs {
     background-color: #ffffff;
     border-top: 1px solid #666;
     border-bottom: 1px solid #666;
 }
-.new-prototype.school-detail-page .school-profile-tabs ul li {
-    text-align: center;
-    text-transform: uppercase;
-    width: 20%;
-    padding-bottom: 0;
-}
-.new-prototype.school-detail-page .nav-pills > li+li {
-    margin: 0;
-}
-.school-profile-tabs .nav-pills > li.active > a,
-.school-profile-tabs .nav-pills > li > a:hover {
-    border-radius: 0;
-    cursor: pointer;
-}
-.new-prototype .middle-school-tabs-nav .nav-pills > li > a {
+.middle-school-tabs-nav .nav-pills > li > a {
     color: #666;
 }
-.new-prototype .middle-school-tabs-nav .nav-pills > li.active > a {
+.middle-school-tabs-nav .nav-pills > li.active > a {
     background-color: #666;
     color: #ffffff;
 }
-.new-prototype .school-profile-content {
+.school-profile-content {
     margin-top: 40px;
 }
-.new-prototype .school-profile-content .row {
+.school-profile-content .row {
     display: none;
 }
-.new-prototype .school-profile-content .active {
+.school-profile-content .active {
     display: block;
 }
-.new-prototype .force-line-break {
+.force-line-break {
   /* These are technically the same, but use both */
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -627,5 +613,4 @@ and integrated with other styles above
   -moz-hyphens: auto;
   -webkit-hyphens: auto;
   hyphens: auto;
-
 }


### PR DESCRIPTION
@copelco This is just a cleanup job. When we had those two pages live--the old profile page and the new prototype--we used a new-prototype class to differentiate between the appearance of the same dives on the two pages.  That class is no longer needed because the new prototype page has been live, so I have removed the class from the html file and cleaned up CSS accordingly. There should be no difference in appearance between this branch and the master.